### PR TITLE
Make all BuildPath use caps to read files

### DIFF
--- a/src/scripting/MinigameSystem.sp
+++ b/src/scripting/MinigameSystem.sp
@@ -143,7 +143,7 @@ public void LoadMinigameData()
 	// This method is invoked and allows the minigame to add itself to the Minigame-cycle and add itself to forwards.
 
 	// Determine count of Minigames that are available.
-	BuildPath(Path_SM, manifestPath, sizeof(manifestPath), "data/microtf2/minigames.txt");
+	BuildPath(Path_SM, manifestPath, sizeof(manifestPath), "data/microtf2/Minigames.txt");
 
 	Handle kv = CreateKeyValues("Minigames");
 	FileToKeyValues(kv, manifestPath);
@@ -213,7 +213,7 @@ public void LoadBossgameData()
 {
 	char funcName[64];
 	char manifestPath[128];
-	BuildPath(Path_SM, manifestPath, sizeof(manifestPath), "data/microtf2/bossgames.txt");
+	BuildPath(Path_SM, manifestPath, sizeof(manifestPath), "data/microtf2/Bossgames.txt");
 
 	Handle kv = CreateKeyValues("Bossgames");
 	FileToKeyValues(kv, manifestPath);

--- a/src/scripting/SpecialRounds.sp
+++ b/src/scripting/SpecialRounds.sp
@@ -34,7 +34,7 @@ stock void InitializeSpecialRounds()
 	LogMessage("Initializing Special Rounds...");
 
 	char path[128];
-	BuildPath(Path_SM, path, sizeof(path), "data/microtf2/specialrounds.txt");
+	BuildPath(Path_SM, path, sizeof(path), "data/microtf2/SpecialRounds.txt");
 
 	Handle kv = CreateKeyValues("SpecialRounds");
 	FileToKeyValues(kv, path);

--- a/src/scripting/SpecialRounds.sp
+++ b/src/scripting/SpecialRounds.sp
@@ -428,7 +428,7 @@ stock void Special_LoadFakeConditions()
 	LogMessage("Initializing Special Round random non-existant conditions");
 
 	char manifestPath[128];
-	BuildPath(Path_SM, manifestPath, sizeof(manifestPath), "data/microtf2/specialroundfakeconditions.txt");
+	BuildPath(Path_SM, manifestPath, sizeof(manifestPath), "data/microtf2/SpecialRoundFakeConditions.txt");
 
 	Handle file = OpenFile(manifestPath, "r"); // Only need r for read
 

--- a/src/scripting/System.sp
+++ b/src/scripting/System.sp
@@ -180,7 +180,7 @@ public void System_OnMapStart()
 public void LoadGamemodeInfo()
 {
 	char gamemodeManifestPath[128];
-	BuildPath(Path_SM, gamemodeManifestPath, sizeof(gamemodeManifestPath), "data/microtf2/gamemodes.txt");
+	BuildPath(Path_SM, gamemodeManifestPath, sizeof(gamemodeManifestPath), "data/microtf2/Gamemodes.txt");
 
 	Handle kv = CreateKeyValues("Gamemodes");
 	FileToKeyValues(kv, gamemodeManifestPath);


### PR DESCRIPTION
I get this error when using 2019.1 version
```Failed to open SpecialRoundFakeConditions.txt in data/microtf2! Lagspikes may occur during the game.```

Seems to be that `OpenFile` have problems trying to open when not caps, while it still works fine when opening other files. Even though i don't think you have a problem with not caps, may be to do with server perms.

Also bit of Inconsistency fix where some `BuildPath` use caps and some don't use caps.