### PR TITLE
Force reset convar on plugin end or map end

### DIFF
--- a/src/scripting/AS-MicroTF2.sp
+++ b/src/scripting/AS-MicroTF2.sp
@@ -77,7 +77,10 @@ public void OnPluginStart()
 
 public void OnPluginEnd()
 {
-	ResetConVars();
+	if (IsPluginEnabled)
+	{
+		ResetConVars();
+	}
 }
 
 public void OnMapStart()
@@ -104,9 +107,9 @@ public void OnMapEnd()
 	{
 		Call_StartForward(GlobalForward_OnMapEnd);
 		Call_Finish();
+		
+		ResetConVars();
 	}
-	
-	ResetConVars();
 }
 
 public Action Timer_GameLogic_EngineInitialisation(Handle timer)

--- a/src/scripting/AS-MicroTF2.sp
+++ b/src/scripting/AS-MicroTF2.sp
@@ -75,6 +75,11 @@ public void OnPluginStart()
 	InitializeSystem();
 }
 
+public void OnPluginEnd()
+{
+	ResetConVars();
+}
+
 public void OnMapStart()
 {
 	IsPluginEnabled = IsWarioWareMap();
@@ -100,6 +105,8 @@ public void OnMapEnd()
 		Call_StartForward(GlobalForward_OnMapEnd);
 		Call_Finish();
 	}
+	
+	ResetConVars();
 }
 
 public Action Timer_GameLogic_EngineInitialisation(Handle timer)


### PR DESCRIPTION
small, but major bug. Whenever server changes map or plugin unloads (e.g. rocking the vote) before microtf2 actually ends, convars did not get reset so things can break in other gamemodes.

Probably only need either `OnPluginEnd` or `OnMapEnd`, but may well then do both just to make sure.