### PR TITLE
Fix missing participating checks on few bossgames

### DIFF
--- a/src/scripting/Bossgames/Bossgame1.sp
+++ b/src/scripting/Bossgames/Bossgame1.sp
@@ -118,7 +118,7 @@ public void Bossgame1_BossCheck()
 		{
 			Player player = new Player(i);
 
-			if (player.IsValid && player.IsAlive && IsPlayerParticipant[i])
+			if (player.IsValid && player.IsAlive && player.IsParticipating)
 			{
 				alivePlayers++;
 

--- a/src/scripting/Bossgames/Bossgame3.sp
+++ b/src/scripting/Bossgames/Bossgame3.sp
@@ -160,7 +160,7 @@ public void Bossgame3_OnBossStopAttempt()
 	{
 		Player player = new Player(i);
 
-		if (player.IsValid && player.IsAlive)
+		if (player.IsValid && player.IsAlive && player.IsParticipating)
 		{
 			TFTeam team = player.Team;
 

--- a/src/scripting/Bossgames/Bossgame4.sp
+++ b/src/scripting/Bossgames/Bossgame4.sp
@@ -208,7 +208,7 @@ public void Bossgame4_OnBossStopAttempt()
 		{
 			Player player = new Player(i);
 
-			if (player.IsValid && player.IsAlive && PlayerStatus[i] != PlayerStatus_Failed)
+			if (player.IsValid && player.IsAlive && player.IsParticipating && PlayerStatus[i] != PlayerStatus_Failed)
 			{
 				alivePlayers++;
 			}

--- a/src/scripting/Bossgames/Bossgame5.sp
+++ b/src/scripting/Bossgames/Bossgame5.sp
@@ -130,7 +130,7 @@ public void Bossgame5_OnBossStopAttempt()
 	{
 		Player player = new Player(i);
 
-		if (player.IsInGame && player.IsAlive)
+		if (player.IsInGame && player.IsAlive && player.IsParticipating)
 		{
 			alivePlayers++;
 


### PR DESCRIPTION
Few situations where bossgame suppose to end now, but someone joined mid-game as non-participant, causing bossgame to not end until timer runs out.