### PR TITLE
Fix able to win platform bossgame while not participating

### DIFF
--- a/src/scripting/Bossgames/Bossgame4.sp
+++ b/src/scripting/Bossgames/Bossgame4.sp
@@ -190,7 +190,7 @@ public void Bossgame4_OnMinigameFinish()
 		{
 			Player player = new Player(i);
 
-			if (player.IsValid && PlayerStatus[i] != PlayerStatus_Failed)
+			if (player.IsValid && player.IsAlive && player.IsParticipating && PlayerStatus[i] != PlayerStatus_Failed)
 			{
 				PlayerStatus[i] = PlayerStatus_Winner;
 			}


### PR DESCRIPTION
Big exploit found by @karlwantstodie
Simply just join spectator, then join one of team during platform bossgame to win and get 5 points. Missing participating player check, similar to #128