### PR TITLE
Fix memory leak from annotations

### DIFF
--- a/src/scripting/Stocks.sp
+++ b/src/scripting/Stocks.sp
@@ -178,6 +178,7 @@ stock void ShowAnnotationWithBitfield(int client, int attachToEntity, float life
 	event.SetBool("show_effect", false);
 	event.SetInt("visibilityBitfield", bitfield);
 	event.FireToClient(client);
+	delete event;
 	
 	g_iAnnotationEventId++;
 }


### PR DESCRIPTION
This commit https://github.com/gemidyne/microtf2/commit/e2e6db423b47cd0c1e158623866797ad7cdc37a0 changes the way event is handled. `Event.Fire`/`FireEvent` auto deletes handle itself, but `Event.FireToClient` does NOT auto deletes handle itself, so that has to be deleted manually.

Untested but im 99% sure thats why as i got error log from that, plugin unloads itself