### PR TITLE
Actual fix on memory leak from annotations

### DIFF
--- a/src/scripting/Stocks.sp
+++ b/src/scripting/Stocks.sp
@@ -178,7 +178,7 @@ stock void ShowAnnotationWithBitfield(int client, int attachToEntity, float life
 	event.SetBool("show_effect", false);
 	event.SetInt("visibilityBitfield", bitfield);
 	event.FireToClient(client);
-	delete event;
+	event.Cancel();	//Free the handle memory
 	
 	g_iAnnotationEventId++;
 }


### PR DESCRIPTION
I'm almost correct with #158 fixes leak, however i missed that `delete`/`CloseHandle` does not work on event handles, instead must be closed from `event.Cancel()`/`CancelCreatedEvent` unlike many other handles. Sorry that my previous PR still causing leaks!