### PR TITLE
Fix non-participants able to make knockback in stay on ground minigame

### DIFF
--- a/src/scripting/Minigames/Minigame22.sp
+++ b/src/scripting/Minigames/Minigame22.sp
@@ -72,7 +72,7 @@ public void Minigame22_OnPlayerTakeDamage(int victimId, int attackerId, float da
 	Player attacker = new Player(attackerId);
 	Player victim = new Player(victimId);
 
-	if (attacker.IsValid && victim.IsValid)
+	if (attacker.IsValid && victim.IsValid && attacker.IsParticipating && victim.IsParticipating)
 	{
 		float ang[3];
 		float vel[3];


### PR DESCRIPTION
I lost a sudden death special round with 2 players left because of this bug :(