### PR TITLE
Replace deprecated function from econ data

### DIFF
--- a/src/scripting/Weapons.sp
+++ b/src/scripting/Weapons.sp
@@ -36,7 +36,7 @@ stock void Weapons_EquipWeaponByItemIndex(int client, int weaponLookupIndex)
 		return;
 	}
 
-	int weaponSlot = TF2Econ_GetItemSlot(weaponLookupIndex, player.Class);
+	int weaponSlot = TF2Econ_GetItemLoadoutSlot(weaponLookupIndex, player.Class);
 	int weaponQuality = TF2Econ_GetItemQuality(weaponLookupIndex);
 	char weaponClassname[64];
 	int minWeaponLevel;


### PR DESCRIPTION
tf_econ_data deprecated `TF2Econ_GetItemSlot` a year ago, in favour of `TF2Econ_GetItemLoadoutSlot`.
https://github.com/nosoop/SM-TFEconData/commit/b9034c4167b0862d3aef1cbb06efedff5f0a3065

This change will break servers using tf_econ_data 0.17.0 or older, but atleast resolves warning when compiling plugin with newer include.