### PR TITLE
Remove usage of TF2_CalcIsAttackCritical entirely

### DIFF
--- a/src/scripting/AS-MicroTF2.sp
+++ b/src/scripting/AS-MicroTF2.sp
@@ -554,7 +554,6 @@ public Action Timer_GameLogic_EndMinigame(Handle timer)
 	IsBlockingDeathCommands = true;
 	IsBlockingTaunts = true;
 	IsOnlyBlockingDamageByPlayers = false;
-	ForceCalculationCritical = false;
 
 	for (int i = 1; i <= MaxClients; i++)
 	{
@@ -921,7 +920,6 @@ public Action Timer_GameLogic_GameOverStart(Handle timer)
 	PrintToChatAll("[DEBUG] GameOverStart");
 	#endif
 
-	ForceCalculationCritical = false;
 	IsBlockingDamage = false;
 	IsBlockingDeathCommands = false;
 	IsBlockingTaunts = false;

--- a/src/scripting/Events.sp
+++ b/src/scripting/Events.sp
@@ -320,27 +320,6 @@ public void Event_PlayerSappedObject(Handle event, const char[] name, bool dontB
 	}
 }
 
-public Action TF2_CalcIsAttackCritical(int client, int weapon, char[] weaponname, bool &result)
-{
-	if (!IsPluginEnabled)
-	{
-		return Plugin_Continue;
-	}
-
-	if (GlobalForward_OnPlayerCalculateCritical != INVALID_HANDLE && IsPlayerParticipant[client])
-	{
-		Call_StartForward(GlobalForward_OnPlayerCalculateCritical);
-		Call_PushCell(client);
-		Call_PushCell(weapon);
-		Call_PushString(weaponname);
-		Call_Finish();
-	}
-	
-	result = ForceCalculationCritical;
-	return Plugin_Changed;
-}
-
-
 public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3], int &weapon)
 {
 	if (!IsPluginEnabled)
@@ -572,7 +551,8 @@ public void TF2_OnConditionAdded(int client, TFCond condition)
 			TFCond_Taunting,
 			TFCond_Bleeding,
 			TFCond_RuneHaste,
-			TFCond_CritCola:
+			TFCond_CritCola,
+			TFCond_HalloweenCritCandy:
 		{
 			removeCondition = false;
 		}

--- a/src/scripting/Forwards.sp
+++ b/src/scripting/Forwards.sp
@@ -218,16 +218,6 @@ Handle GlobalForward_OnPlayerStunned;
 Handle GlobalForward_OnPlayerSappedObject;
 
 /**
- * Forward is called when a Player's Critical Chance is calculated.
- *
- * @param Client that this is being calculated for
- * @param Weapon Entity Index
- * @param Weapon Name 
- * @noreturn
- */
-Handle GlobalForward_OnPlayerCalculateCritical;
-
-/**
  * Forward is called when a Player runs a command.
  *
  * @param Client who is running command
@@ -321,7 +311,6 @@ stock void InitializeForwards()
 	GlobalForward_OnPlayerClassChange = CreateForward(ET_Ignore, Param_Any, Param_Any);
 	GlobalForward_OnPlayerStunned = CreateForward(ET_Ignore, Param_Any, Param_Any);
 	GlobalForward_OnPlayerSappedObject = CreateForward(ET_Ignore, Param_Any, Param_Any);
-	GlobalForward_OnPlayerCalculateCritical = CreateForward(ET_Ignore, Param_Any, Param_Any, Param_String);
 	GlobalForward_OnPlayerRunCmd = CreateForward(ET_Ignore, Param_Any, Param_CellByRef, Param_CellByRef, Param_Array, Param_Array, Param_CellByRef);
 	GlobalForward_OnBossStopAttempt = CreateForward(ET_Single);
 	GlobalForward_OnTfRoundStart = CreateForward(ET_Ignore);
@@ -357,7 +346,6 @@ stock void RemoveForwardsFromMemory()
 	SafelyRemoveAllFromForward(GlobalForward_OnPlayerClassChange);
 	SafelyRemoveAllFromForward(GlobalForward_OnPlayerStunned);
 	SafelyRemoveAllFromForward(GlobalForward_OnPlayerSappedObject);
-	SafelyRemoveAllFromForward(GlobalForward_OnPlayerCalculateCritical);
 	SafelyRemoveAllFromForward(GlobalForward_OnPlayerRunCmd);
 	SafelyRemoveAllFromForward(GlobalForward_OnBossStopAttempt);
 	SafelyRemoveAllFromForward(GlobalForward_OnTfRoundStart);

--- a/src/scripting/Header.sp
+++ b/src/scripting/Header.sp
@@ -67,7 +67,6 @@ bool IsPlayerParticipant[MAXPLAYERS+1] = false;
 bool IsPlayerWinner[MAXPLAYERS+1] = false;
 bool HideHudGamemodeText = false;
 bool AllowCosmetics = false;
-bool ForceCalculationCritical = false;
 bool IsPlayerUsingLegacyDirectX[MAXPLAYERS+1] = false;
 
 #if defined USE_MAXSPEED_HOOK

--- a/src/scripting/Internal.sp
+++ b/src/scripting/Internal.sp
@@ -173,7 +173,6 @@ stock void ResetGamemode()
 	IsOnlyBlockingDamageByPlayers = false;
 	IsBlockingDeathCommands = true;
 	IsBlockingTaunts = true;
-	ForceCalculationCritical = false;
 
 	SetTeamScore(view_as<int>(TFTeam_Red), 0);
 	SetTeamScore(view_as<int>(TFTeam_Blue), 0);

--- a/src/scripting/MethodMaps/Player.inc
+++ b/src/scripting/MethodMaps/Player.inc
@@ -439,6 +439,7 @@ methodmap Player __nullable__
         this.RemoveCondition(TFCond_Bleeding);
         this.RemoveCondition(TFCond_RuneHaste);
         this.RemoveCondition(TFCond_CritCola);
+        this.RemoveCondition(TFCond_HalloweenCritCandy);
         this.RemoveCondition(TFCond_Taunting);
     }
 

--- a/src/scripting/Minigames/Minigame26.sp
+++ b/src/scripting/Minigames/Minigame26.sp
@@ -57,7 +57,6 @@ public void Minigame26_OnMinigameSelectedPre()
 		while (Minigame26_VictimClass == TFClass_Heavy);
 
 		IsBlockingDamage = true;
-		ForceCalculationCritical = true;
 	}
 }
 
@@ -224,6 +223,7 @@ void Minigame26_SetupAttacker(Player player)
 	player.Status = PlayerStatus_NotWon;
 
 	player.AddCondition(TFCond_CritCola, 4.0);
+	player.AddCondition(TFCond_HalloweenCritCandy, 4.0);
 	player.AddCondition(TFCond_RuneHaste, 4.0);
 }
 


### PR DESCRIPTION
When any plugin uses this forward, serverside crit calculation desyncs from clientside crit calculation, even if the forward solely returns Plugin_Continue.
Any time MicroTF2 is loaded, 'fake crits' start occurring on certain server setups, even if IsPluginEnabled is false.
None of the minigames seem to use this forward aside from 26, which can easily be replaced by HalloweenCritCandy.
If crits need to be disabled, either the attribute for 'no random crits' or the cvar for disabling crits can be used.