### PR TITLE
Set health to 1000 during Platforms minigame such that 5 crits can't kill anybody

### DIFF
--- a/src/scripting/Minigames/Minigame12.sp
+++ b/src/scripting/Minigames/Minigame12.sp
@@ -74,7 +74,7 @@ public void Minigame12_OnMinigameSelected(int client)
 
 		player.ResetWeapon(false);
 		player.SetGodMode(false);
-		player.ResetHealth();
+		player.SetHealth(1000);
 	}
 }
 


### PR DESCRIPTION
There's only enough time to land 5 melee attacks before the minigame ends, and with the (hopefully temporary as it'll be fixed in SM) change to remove the CalcIsAttackCritical handling, players can potentially crit and kill others instead of simply knocking them off, so this HP value will make it so nobody dies to melee. Since the trigger_hurt is set to 99999 damage this shouldn't affect the water killing people.