### PR TITLE
Replace SteamTools dependency with SteamWorks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The "dev" branch is used for the latest development version of the gamemode. Thi
 
 The gamemode utilises the following extensions and plugins to run:
 
-- SteamTools extension - https://forums.alliedmods.net/showthread.php?t=170630 (Used for setting the game description)
+- SteamWorks extension - https://forums.alliedmods.net/showthread.php?t=229556 (Used for setting the game description)
 - TF2Items extension - https://forums.alliedmods.net/showthread.php?t=115100 (Used for blocking wearables)
 - TF2Attributes plugin - https://github.com/FlaminSarge/tf2attributes (Used for applying attributes to weapons)
 - TFEconData plugin - https://github.com/nosoop/SM-TFEconData (Used for giving weapons to players)

--- a/src/scripting/AS-MicroTF2.sp
+++ b/src/scripting/AS-MicroTF2.sp
@@ -20,7 +20,7 @@
 #define REQUIRE_EXTENSIONS
 
 #include <sdkhooks>
-#include <steamtools>
+#include <SteamWorks>
 #include <tf2items>
 #include <tf2attributes>
 
@@ -89,9 +89,9 @@ public void OnPluginStart()
 		SetFailState("The TF2Items Extension is not loaded.");
 	}
 
-	if (GetExtensionFileStatus("steamtools.ext") < 1)
+	if (GetExtensionFileStatus("SteamWorks.ext") < 1)
 	{
-		SetFailState("The SteamTools Extension is not loaded.");
+		SetFailState("The SteamWorks Extension is not loaded.");
 	}
 
 	LoadTranslations("microtf2.phrases.txt");

--- a/src/scripting/System.sp
+++ b/src/scripting/System.sp
@@ -47,7 +47,7 @@ public void System_OnMapStart()
 
 	char gameDescription[32];
 	Format(gameDescription, sizeof(gameDescription), "WarioWare (v%s)", PLUGIN_VERSION);
-	Steam_SetGameDescription(gameDescription);
+	SteamWorks_SetGameDescription(gameDescription);
 
 	g_iActiveMinigameId = 0;
 	g_iActiveBossgameId = 0;


### PR DESCRIPTION
As of the latest TF2 update, the SteamTools extension has been crashing many people's servers and needs to be recompiled against newest interfaces to work properly again. However, the extension is not actively supported by its developer anymore so this is unlikely to happen.

A much better alternative is the [SteamWorks](https://forums.alliedmods.net/showthread.php?t=229556) extension, which still works after the latest update and offers similar functionality. The general consensus in the SourceMod community overall is that people should not be using SteamTools anymore.

`Steam_SetGameDescription` -> `SteamWorks_SetGameDescription`

I have tested these changes and they cause no issues.