### PR TITLE
Fix BossGameThreshold in special round config

### DIFF
--- a/src/scripting/SpecialRounds.sp
+++ b/src/scripting/SpecialRounds.sp
@@ -52,7 +52,7 @@ void InitializeSpecialRounds()
 		{
 			g_bSpecialRoundSpeedEventsDisabled[i] = (kv.GetNum("DisableSpeedEvents", 0) == 1);
 			g_bSpecialRoundMultiplePlayersOnly[i] = (kv.GetNum("MultiplePlayersOnly", 0) == 1);
-			g_iSpecialRoundBossGameThreshold[i] = kv.GetNum("g_iBossGameThreshold", 0);
+			g_iSpecialRoundBossGameThreshold[i] = kv.GetNum("BossGameThreshold", 0);
 
 			i++;
 		}


### PR DESCRIPTION
[This commit](https://github.com/gemidyne/microtf2/commit/02a39de5b5de43a3aa2ffae83cc9755fb248554f) renames variable from `BossGameThreshold` to `g_iBossGameThreshold`, but it also renames a string that's used to read a keyvalue config, which shouldn't have been changed.