### PR TITLE
Fix players sometimes being teleported out of the map in the Hit The Target microgame

### DIFF
--- a/src/scripting/Minigames/Minigame18.sp
+++ b/src/scripting/Minigames/Minigame18.sp
@@ -284,10 +284,10 @@ public void Minigame18_OnMinigameSelected(int client)
 		float ang[3] = { 0.0, 90.0, 0.0 };
 		float pos[3];
 
-		int column = client;
-		int row = 0;
+		int column = (client - 1) % 32;
+		int row = ((client - 1) / 32) % 2;
 
-		pos[0] = 10406.0 + float(column*60); 
+		pos[0] = 10466.0 + float(column*60); 
 		pos[1] = 7100.0 - float(row*100);
 		pos[2] = -260.0;
 


### PR DESCRIPTION
Makes it so teleport positions for Hit The Target (microgame 18) loop back every 32nd client to prevent them from going outside the playable area.