### PR TITLE
Remove mp_idlemaxtime from ConVars.sp

### DIFF
--- a/src/scripting/ConVars.sp
+++ b/src/scripting/ConVars.sp
@@ -89,7 +89,6 @@ void ResetConVars()
 	ResetConVar(FindConVar("mp_waitingforplayers_time"));
 	ResetConVar(FindConVar("mp_disable_respawn_times"));
 	ResetConVar(FindConVar("mp_respawnwavetime"));
-	ResetConVar(FindConVar("mp_idlemaxtime"));
 
 	// TeamFortress ConVars
 	ResetConVar(FindConVar("tf_avoidteammates_pushaway"));
@@ -106,7 +105,6 @@ void PrepareConVars()
 	SetConVarInt(FindConVar("mp_waitingforplayers_time"), g_hConVarWaitingForPlayersTime.IntValue);
 	SetConVarInt(FindConVar("mp_disable_respawn_times"), 0);
 	SetConVarInt(FindConVar("mp_respawnwavetime"), 9999);
-	SetConVarInt(FindConVar("mp_idlemaxtime"), 8);
 	SetConVarInt(FindConVar("tf_avoidteammates_pushaway"), 0);
 	SetConVarFloat(FindConVar("tf_max_health_boost"), 1.0);
 	SetConVarFloat(FindConVar("tf_airblast_cray_ground_minz"), 268.3281572999747);


### PR DESCRIPTION
`mp_idlemaxtime` only affects the default AFK auto-kick (controlled by `mp_idledealmethod`), and server operators may choose to use a third-party AFK Manager instead, in which case `mp_idlemaxtime` would do nothing.

This pull request has the same principle as two other commits:
https://github.com/gemidyne/microtf2/commit/166a9275899ab82480b7d0e19eb628d9a7c7c33c
https://github.com/gemidyne/microtf2/commit/ba14bd1f263ca2fa76080108697343830177c426